### PR TITLE
Feature/glblagctwo 984

### DIFF
--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -20,6 +20,7 @@ var DEFAULT_AGGREGATION_LIMIT = 0;//0=>Integer.MAX_VALUE
 var DEFAULT_TOP_HITS_AGGREGATION_LIMIT = 10; //Cannot be zero. NOTE: Default number of responses in top_hit aggregation is 10.
 var DEFAULT_SIMPLE_SEARCH_LIMIT = 1000; //simple searches don't specify a limit, and are only used internally for autoupdating
 var defaultOptions = {
+    asyncInMemory: false,
     graphDepth: {
        default: 3
     }
@@ -952,7 +953,7 @@ ElasticHarvest.prototype.enableAutoIndexUpdateOnModelUpdate = function (endpoint
     var _this = this;
     if(!!this.harvest_app.options.oplogConnectionString) {
         console.warn("[Elastic-Harvest] Will sync "+endpoint+" data via oplog");
-        this.harvest_app.onChange(endpoint,{insert:resourceChanged,update:resourceChanged,delete: resourceChanged});
+        this.harvest_app.onChange(endpoint,{insert:resourceChanged,update:resourceChanged,delete: resourceChanged, asyncInMemory: _this.options.asyncInMemory});
 
         function resourceChanged (resourceId) {
             console.log("[Elastic-Harvest] Syncing Change @" + idField + ' : ' + resourceId);

--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -1046,7 +1046,7 @@ ElasticHarvest.prototype.enableAutoSync= function(){
     var _this = this;
     if(!!this.harvest_app.options.oplogConnectionString){
         console.warn("[Elastic-Harvest] Will sync primary resource data via oplog");
-        this.harvest_app.onChange(endpoint,{insert:resourceChanged,update:resourceChanged,delete: resourceDeleted});
+        this.harvest_app.onChange(endpoint,{insert:resourceChanged,update:resourceChanged,delete: resourceDeleted, asyncInMemory: _this.options.asyncInMemory});
         function resourceDeleted(resourceId){
             _this.delete(resourceId)
                 .catch(function(error){

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "request": "2.40.0",
     "underscore.string": "~2.3.2",
     "woodman": "1.1.x",
-    "harvester": "git+https://github.com/agco/harvesterjs.git#2.0.1"
+    "harvester": "git+https://github.com/agco/harvesterjs.git#5fa37b12ccdd888700c186115498753ff15870ba"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "request": "2.40.0",
     "underscore.string": "~2.3.2",
     "woodman": "1.1.x",
-    "harvester": "git+https://github.com/agco/harvesterjs.git#5fa37b12ccdd888700c186115498753ff15870ba"
+    "harvester": "git+https://github.com/agco/harvesterjs.git#2.2.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
optionally pass in asyncInMemory option when initialising Elastic Harvesterjs to speed up indexing performance

works in tandem with : https://github.com/agco/harvesterjs/pull/139
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/elastic-harvesterjs/pull/64%23discussion_r38808275%22%2C%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/64%23discussion_r38809130%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2067cc6279557af94e28133ecb1ee83107725591c7%20package.json%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/64%23discussion_r38808275%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20we%20put%20here%20a%20released%20version%3F%22%2C%20%22created_at%22%3A%20%222015-09-05T06%3A28%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/431064%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blabno%22%7D%7D%2C%20%7B%22body%22%3A%20%22yes%2C%20but%20there%20is%20an%20open%20PR%20which%20has%20to%20be%20merged%20first%20%5Cr%5Cnhttps%3A//github.com/agco/harvesterjs/pull/139%22%2C%20%22created_at%22%3A%20%222015-09-05T09%3A11%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666156%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kristofsajdak%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20package.json%3AL24-31%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 67cc6279557af94e28133ecb1ee83107725591c7 package.json 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/elastic-harvesterjs/pull/64#discussion_r38808275'>File: package.json:L24-31</a></b>
- <a href='https://github.com/blabno'><img border=0 src='https://avatars.githubusercontent.com/u/431064?v=3' height=16 width=16'></a> Shouldn't we put here a released version?
- <a href='https://github.com/kristofsajdak'><img border=0 src='https://avatars.githubusercontent.com/u/666156?v=3' height=16 width=16'></a> yes, but there is an open PR which has to be merged first
https://github.com/agco/harvesterjs/pull/139


<a href='https://www.codereviewhub.com/agco/elastic-harvesterjs/pull/64?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/elastic-harvesterjs/pull/64?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/elastic-harvesterjs/pull/64'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>