### PR TITLE
fixed sorting within top_hits aggregation

### DIFF
--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -853,9 +853,12 @@ ElasticHarvest.prototype.getEsQueryBody = function (predicates, nestedPredicates
                     _.each(aggregationObject.sort.split(','),function(sortParam) {
                         var sortDirection = (sortParam[0]!="-"?"asc":"desc");
                         sortDirection=="desc" && (sortParam = sortParam.substr(1));
+                        var lastDot = sortParam.lastIndexOf('.')
                         shallowAggs.top_hits.sort= shallowAggs.top_hits.sort || [];
                         var sortTerm = {};
-                        sortTerm[sortParam]={"order":sortDirection};
+                        var sortField = sortParam.substring(lastDot + 1);
+                        var nestedPath = sortParam.substring(0, lastDot);
+                        sortTerm[sortField]={"order":sortDirection, "nested_path": nestedPath, "ignore_unmapped":true};
                         shallowAggs.top_hits.sort.push(sortTerm);
                     });
                 }

--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -853,12 +853,18 @@ ElasticHarvest.prototype.getEsQueryBody = function (predicates, nestedPredicates
                     _.each(aggregationObject.sort.split(','),function(sortParam) {
                         var sortDirection = (sortParam[0]!="-"?"asc":"desc");
                         sortDirection=="desc" && (sortParam = sortParam.substr(1));
-                        var lastDot = sortParam.lastIndexOf('.')
                         shallowAggs.top_hits.sort= shallowAggs.top_hits.sort || [];
                         var sortTerm = {};
-                        var sortField = sortParam.substring(lastDot + 1);
-                        var nestedPath = sortParam.substring(0, lastDot);
-                        sortTerm[sortField]={"order":sortDirection, "nested_path": nestedPath, "ignore_unmapped":true};
+                        var lastDot = sortParam.lastIndexOf('.');
+                        if (lastDot !== -1) {
+                            var sortField = sortParam.substring(lastDot + 1);
+                            var nestedPath = sortParam.substring(0, lastDot);
+                            sortTerm[sortField]={"order":sortDirection, "nested_path": nestedPath, "ignore_unmapped":true};
+                        } else {
+                            var sortField = sortParam;
+                            sortTerm[sortField]={"order":sortDirection, "ignore_unmapped":true};
+                        }
+
                         shallowAggs.top_hits.sort.push(sortTerm);
                     });
                 }


### PR DESCRIPTION
changing the sort clause to use a nested_path property

sortTerm[sortField]={"order":sortDirection, "nested_path": nestedPath, "ignore_unmapped":true};
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/elastic-harvesterjs/pull/68?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/elastic-harvesterjs/pull/68'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>