### PR TITLE
expose function to clear cache

### DIFF
--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -37,7 +37,6 @@ function ElasticHarvest(harvest_app,es_url,index,type,options) {
         this.harvest_app = harvest_app;
         Cache.initCache(harvest_app.adapter)
         this.singletonCache = Cache.getInstance();
-        this.clearCache = this.singletonCache.clear
     }else{
         console.warn("[Elastic-Harvest] Using elastic-harvester without a harvest-app. Functionality will be limited.");
     }

--- a/elastic-harvester.js
+++ b/elastic-harvester.js
@@ -37,6 +37,7 @@ function ElasticHarvest(harvest_app,es_url,index,type,options) {
         this.harvest_app = harvest_app;
         Cache.initCache(harvest_app.adapter)
         this.singletonCache = Cache.getInstance();
+        this.clearCache = this.singletonCache.clear
     }else{
         console.warn("[Elastic-Harvest] Using elastic-harvester without a harvest-app. Functionality will be limited.");
     }

--- a/lib/singletonAdapterCache.js
+++ b/lib/singletonAdapterCache.js
@@ -15,22 +15,21 @@ function _createCache(adapter) {
         _adapter: adapter,
         _cache: {},
         find: function (collectionName, id) {
-            var _this = this;
-            this._cache[collectionName] = this._cache[collectionName] || {};
-            if (this._cache[collectionName][id]) {
-                return Promise.resolve(this._cache[collectionName][id]);
+            _singletonCache._cache[collectionName] = _singletonCache._cache[collectionName] || {};
+            if (_singletonCache._cache[collectionName][id]) {
+                return Promise.resolve(_singletonCache._cache[collectionName][id]);
             }
-            return this._adapter.find(collectionName, id)
+            return _singletonCache._adapter.find(collectionName, id)
                 .then(function (doc) {
-                    if (doc) _this._cache[collectionName][id] = doc;
+                    if (doc) _singletonCache._cache[collectionName][id] = doc;
                     return doc;
                 })
         },
         findMany: function (collectionName, ids) {
-            return this._adapter.findMany(collectionName, ids);
+            return _singletonCache._adapter.findMany(collectionName, ids);
         },
         clear: function () {
-            this._cache = {};
+            _singletonCache._cache = {};
         }
     }
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23issuecomment-267332391%22%2C%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23discussion_r92616810%22%2C%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23discussion_r92617230%22%2C%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23issuecomment-267369584%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23issuecomment-267332391%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/9296505/badge%29%5D%28https%3A//coveralls.io/builds/9296505%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2077.676%25%20when%20pulling%20%2A%2A1b63b1f18fdd92bfa522fa726d963a3a15b94158%20on%20feature/lightweight-adapter-cache%2A%2A%20into%20%2A%2Aec5b32a724eb92662d734fcae64dddda4a79ebe2%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-12-15T13%3A53%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/9299241/badge%29%5D%28https%3A//coveralls.io/builds/9299241%29%5Cn%5CnCoverage%20decreased%20%28-0.02%25%29%20to%2077.656%25%20when%20pulling%20%2A%2A9335d676fa4827c02e1cf34b80dee2ed6bcb741e%20on%20feature/lightweight-adapter-cache%2A%2A%20into%20%2A%2Aec5b32a724eb92662d734fcae64dddda4a79ebe2%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-12-15T16%3A17%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201b63b1f18fdd92bfa522fa726d963a3a15b94158%20elastic-harvester.js%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/elastic-harvesterjs/pull/91%23discussion_r92616810%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20know%2C%20if%20you%20had%20just%20called%20this.singetonCache.clear%2C%20you%20wouldn%27t%20need%20to%20rewrite%20the%20cache%20to%20avoid%20using%20this.%20Separately%2C%20you%20could%20use%20_.bind.%22%2C%20%22created_at%22%3A%20%222016-12-15T14%3A19%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22you%20can%20merge%20if%20you%5Cu2019re%20happy%20with%20it%2C%20but%20i%20think%20this%20approach%20is%20less%20readable.%20%28it%20would%20be%20clearer%20if%20you%20were%20calling%20this.singletonCache.clear%28%29%20instead%20of%20this.clearCache%28%29%29%22%2C%20%22created_at%22%3A%20%222016-12-15T14%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20elastic-harvester.js%3AL37-44%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/elastic-harvesterjs/pull/91#issuecomment-267332391'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/9296505/badge)](https://coveralls.io/builds/9296505)
Coverage remained the same at 77.676% when pulling **1b63b1f18fdd92bfa522fa726d963a3a15b94158 on feature/lightweight-adapter-cache** into **ec5b32a724eb92662d734fcae64dddda4a79ebe2 on develop**.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/9299241/badge)](https://coveralls.io/builds/9299241)
Coverage decreased (-0.02%) to 77.656% when pulling **9335d676fa4827c02e1cf34b80dee2ed6bcb741e on feature/lightweight-adapter-cache** into **ec5b32a724eb92662d734fcae64dddda4a79ebe2 on develop**.
- [ ] <a href='#crh-comment-Pull 1b63b1f18fdd92bfa522fa726d963a3a15b94158 elastic-harvester.js 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/elastic-harvesterjs/pull/91#discussion_r92616810'>File: elastic-harvester.js:L37-44</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> you know, if you had just called this.singetonCache.clear, you wouldn't need to rewrite the cache to avoid using this. Separately, you could use _.bind.
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> you can merge if you’re happy with it, but i think this approach is less readable. (it would be clearer if you were calling this.singletonCache.clear() instead of this.clearCache())


<a href='https://www.codereviewhub.com/agco/elastic-harvesterjs/pull/91?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/elastic-harvesterjs/pull/91?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/elastic-harvesterjs/pull/91'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>